### PR TITLE
fix: chemin index serveur

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -24,4 +24,4 @@ COPY --from=builder ./app/. .
 
 EXPOSE 5000
 WORKDIR /app/server
-CMD ["node", "dist/src/index.js"]
+CMD ["node", "dist/index.js"]

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
-    "start": "node dist/src/index.js",
+    "start": "node dist/index.js",
     "dev": "tsup src/index.ts migrations --watch . --onSuccess 'yarn run start'",
     "build": "tsup src/index.ts migrations",
     "typecheck": "tsc",


### PR DESCRIPTION
Le build se trouve dans `dist/index.js` et non `dict/src/index.js`