### PR TITLE
chore: Augmentation du healthcheck Clamav

### DIFF
--- a/.infra/docker-compose.preview.yml
+++ b/.infra/docker-compose.preview.yml
@@ -86,7 +86,7 @@ services:
       test: ["CMD", "/usr/local/bin/clamdcheck.sh"]
       interval: 60s
       retries: 3
-      start_period: 120s
+      start_period: 6m
 
   smtp:
     image: axllent/mailpit:v1.5.5

--- a/.infra/docker-compose.yml
+++ b/.infra/docker-compose.yml
@@ -190,7 +190,7 @@ services:
       test: ["CMD", "/usr/local/bin/clamdcheck.sh"]
       interval: 60s
       retries: 3
-      start_period: 120s
+      start_period: 6m
     logging:
       driver: "fluentd"
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,7 +189,7 @@ services:
       test: ["CMD", "/usr/local/bin/clamdcheck.sh"]
       interval: 60s
       retries: 3
-      start_period: 120s
+      start_period: 6m
   
   smtp:
     profiles:


### PR DESCRIPTION
Utilisation de la valeur par defaut https://github.com/Cisco-Talos/clamav-docker/blob/main/clamav/1.1/alpine/Dockerfile#L123C1-L123C12 car le service peut mettre du temps à démarrer