### PR TITLE
chore: reload container doit fonctionner depuis n'iimporte quel cwd

### DIFF
--- a/.infra/playbooks/roles/setup/files/app/tools/reload-containers.sh
+++ b/.infra/playbooks/roles/setup/files/app/tools/reload-containers.sh
@@ -6,10 +6,10 @@ readonly PROJECT_DIR="/opt/bal"
 
 function reload_containers() {
     echo "Rechargement des conteneurs ..."
-    if test -f "docker-compose.recette.yml"; then
-      docker stack deploy -c docker-compose.yml -c docker-compose.recette.yml bal;
+    if test -f "/opt/bal/docker-compose.recette.yml"; then
+      docker stack deploy -c /opt/bal/docker-compose.yml -c /opt/bal/docker-compose.recette.yml bal;
     else
-      docker stack deploy -c docker-compose.yml bal;
+      docker stack deploy -c /opt/bal/docker-compose.yml bal;
     fi
 }
 


### PR DESCRIPTION
Le script de CRON `renew-certificate.sh` utilise le script `reload-containers.sh` sans etre dans le dossier `/opt/bal`.