### PR TITLE
chore: [GENT-44] fix certificate renewal

### DIFF
--- a/.infra/playbooks/roles/setup/files/app/tools/ssl/renew-certificate.sh
+++ b/.infra/playbooks/roles/setup/files/app/tools/ssl/renew-certificate.sh
@@ -6,10 +6,12 @@ readonly DNS_NAME=${1:?"Merci de préciser le nom de domaine"}; shift;
 
 start_reverse_proxy() {
   bash /opt/bal/tools/reload-containers.sh
+  bash /opt/bal/tools/wait-deployment.sh
 }
 
 stop_reverse_proxy() {
   bash /opt/bal/tools/stop-containers.sh reverse_proxy
+  bash /opt/bal/tools/wait-deployment.sh
 }
 
 renew_certificate() {


### PR DESCRIPTION
Il faut attendre que les services soient completement stop, et que le port 80 soit libre avant de start le docker de renew certificat.
