### PR TITLE
chore: ignore pull failures

### DIFF
--- a/.infra/playbooks/deploy.yml
+++ b/.infra/playbooks/deploy.yml
@@ -37,7 +37,7 @@
     - name: Récupération des images docker
       shell:
         chdir: /opt/bal
-        cmd: "sudo docker compose pull"
+        cmd: "sudo docker compose pull --ignore-pull-failures"
 
     - name: Récupération du status de la stack
       shell:


### PR DESCRIPTION
Fixes errors from https://github.com/mission-apprentissage/bal/actions/runs/5584460676/jobs/10205973451#logs

```
TASK [Récupération des images docker] ******************************************
fatal: [141.95.161.235]: FAILED! => {"changed": true, "cmd": "sudo docker compose pull", "delta": "0:00:01.577107", "end": "2023-07-18 09:21:33.559337", "msg": "non-zero return code", "rc": 18, "start": "2023-07-18 09:21:31.982230", "stderr": " server Skipped - Image is already being pulled by processor \n processor Pulling \n nodeexporter Pulling \n reverse_proxy Pulling \n clamav Pulling \n cadvisor Pulling \n ui Pulling \n metabase Pulling \n fluentd Pulling \n cadvisor Pulled \n clamav Pulled \n nodeexporter Pulled \n fluentd Pulled \n metabase Pulled \n reverse_proxy Pulled \n ui Error \n processor Error \nError response from daemon: manifest unknown", "stderr_lines": [" server Skipped - Image is already being pulled by processor ", " processor Pulling ", " nodeexporter Pulling ", " reverse_proxy Pulling ", " clamav Pulling ", " cadvisor Pulling ", " ui Pulling ", " metabase Pulling ", " fluentd Pulling ", " cadvisor Pulled ", " clamav Pulled ", " nodeexporter Pulled ", " fluentd Pulled ", " metabase Pulled ", " reverse_proxy Pulled ", " ui Error ", " processor Error ", "Error response from daemon: manifest unknown"], "stdout": "", "stdout_lines": []}
```