### PR TITLE
fix: migrations build

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -9,8 +9,8 @@
   "type": "module",
   "scripts": {
     "start": "node dist/index.js start",
-    "dev": "tsup src/index.ts src/db/migrations --watch ./src --watch ../shared/src --onSuccess 'yarn run start'",
-    "build": "tsup src/index.ts src/db/migrations",
+    "dev": "tsup src/index.ts src/db/migrations --watch ./src --watch ../shared/src --onSuccess 'yarn run start' --splitting",
+    "build": "tsup src/index.ts src/db/migrations --splitting",
     "typecheck": "tsc --noEmit",
     "migrations:create": "yarn cli migrations:create",
     "cli": "node dist/index.js"


### PR DESCRIPTION
Une des migrations utilise `mongodbUtils`. 

Hors actuellement les fichiers de migrations & l'index sont build séparément. Et donc nous avons 2 `mongodbUtils` différents... Ainsi lorsque l'on init la connection dans `index`, celle-ci n'est pas disponible dans `db/migrations`

L'argument `--splitting` permet de créer des chunks sur le code en commun des entrypoint.