### PR TITLE
feat: fix multiple exact

### DIFF
--- a/server/src/modules/actions/mailingLists.actions.ts
+++ b/server/src/modules/actions/mailingLists.actions.ts
@@ -126,11 +126,6 @@ export const processMailingList = async (payload: IPayload) => {
       .skip(skip)
       .toArray();
 
-    if (!wishes.length) {
-      hasMore = false;
-      continue;
-    }
-
     const output = await formatOutput(mailingList, wishes);
 
     await importDocumentContent(outputDocument, output, (line) => line);


### PR DESCRIPTION
s'il y avait un nombre de lignes avec un multiple de 100, le statut n'était pas mis à jour à cause du `continue`