### PR TITLE
feat: simplify email events

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -114,6 +114,8 @@ fileignoreconfig:
   checksum: e3e123d712465ed963965b5fa36f8d7a15364bbc7107d9d15bef2cc670483d42
 - filename: server/src/utils/jwtUtils.ts
   checksum: 071d8aa92d917d9224e77393463a2af00a65d381637b08140d52d11571dab51c
+- filename: server/static/emails/reset_password.mjml.ejs
+  checksum: 2c2cef4645b11161f129f50c022a1607520c1744b8a1bfe2916ac4e81614c8db
 - filename: server/tests/data/DECA_Extraction MIA-Fake.csv
   checksum: 1c636fe39fedecc8e6bf1b08fe4db680f30c0b5d0cbebc4d8f8a7cc9c2e886ca
 - filename: server/tests/data/akto.ts

--- a/.talismanrc
+++ b/.talismanrc
@@ -115,7 +115,7 @@ fileignoreconfig:
 - filename: server/src/utils/jwtUtils.ts
   checksum: 071d8aa92d917d9224e77393463a2af00a65d381637b08140d52d11571dab51c
 - filename: server/static/emails/reset_password.mjml.ejs
-  checksum: 2c2cef4645b11161f129f50c022a1607520c1744b8a1bfe2916ac4e81614c8db
+  checksum: 1fdd8dce9a765dc2cbf3e5d729b96d417b16b9b8474797b46cf501df73044feb
 - filename: server/tests/data/DECA_Extraction MIA-Fake.csv
   checksum: 1c636fe39fedecc8e6bf1b08fe4db680f30c0b5d0cbebc4d8f8a7cc9c2e886ca
 - filename: server/tests/data/akto.ts

--- a/server/src/common/services/mailer/mailer.ts
+++ b/server/src/common/services/mailer/mailer.ts
@@ -39,7 +39,7 @@ async function sendEmailMessage(template: ITemplate, emailToken: string) {
 
   const { messageId } = await transporter.sendMail({
     from: `${config.email_from} <${config.email}>`,
-    to: template.recipient.email,
+    to: template.to,
     subject: getEmailSubject(template),
     html: await generateHtml(template, emailToken),
     list: {
@@ -93,23 +93,20 @@ export async function renderEmail(token: string) {
   if (!email) {
     return;
   }
-  const { payload } = email;
-  return generateHtml(payload as ITemplate, token);
+  return generateHtml(email.template, token);
 }
 
 export async function generateHtml(template: ITemplate, emailToken: string) {
   const subject = getEmailSubject(template);
   const templateFile = getStaticFilePath(`./emails/${template.name}.mjml.ejs`);
   const buffer = await ejs.renderFile(templateFile, {
-    to: template.recipient.email,
+    to: template.to,
     subject,
-    data: {
-      template,
-      actions: {
-        unsubscribe: getPublicUrl(`/api/emails/${emailToken}/unsubscribe`),
-        preview: getPublicUrl(`/api/emails/${emailToken}/preview`),
-        markAsOpened: getPublicUrl(`/api/emails/${emailToken}/markAsOpened`),
-      },
+    template,
+    actions: {
+      unsubscribe: getPublicUrl(`/api/emails/${emailToken}/unsubscribe`),
+      preview: getPublicUrl(`/api/emails/${emailToken}/preview`),
+      markAsOpened: getPublicUrl(`/api/emails/${emailToken}/markAsOpened`),
     },
     utils: { getPublicUrl },
   });

--- a/server/src/common/utils/jwtUtils.ts
+++ b/server/src/common/utils/jwtUtils.ts
@@ -1,4 +1,5 @@
 import jwt, { SignOptions } from "jsonwebtoken";
+import { ITemplate, zTemplate } from "shared/mailer";
 
 import config from "@/config";
 
@@ -41,6 +42,17 @@ export function createActivationToken(subject: string, options: ICreateTokenOpti
 
 export function createUserTokenSimple(options = {}) {
   return createToken("user", null, options);
+}
+
+export function serializeEmailTemplate(template: ITemplate): string {
+  // We do not set expiry as the result is not used as a token but as serialized data
+  return jwt.sign(template, config.auth.user.jwtSecret, {
+    issuer: config.appName,
+  });
+}
+
+export function deserializeEmailTemplate(data: string): ITemplate {
+  return zTemplate.parse(jwt.verify(data, config.auth.user.jwtSecret));
 }
 
 export const createUserToken = (user: ICreateUserToken, options: ICreateTokenOptions = {}) => {

--- a/server/src/db/migrations/20231109102140-remove-email-events.ts
+++ b/server/src/db/migrations/20231109102140-remove-email-events.ts
@@ -1,0 +1,8 @@
+import { Db, MongoClient } from "mongodb";
+
+export const up = async (db: Db, _client: MongoClient) => {
+  // Removes all emails events
+  await db.collection("events").deleteMany({});
+};
+
+export const down = async (_db: Db, _client: MongoClient) => {};

--- a/server/src/modules/actions/auth.actions.ts
+++ b/server/src/modules/actions/auth.actions.ts
@@ -42,7 +42,8 @@ export const sendResetPasswordEmail = async (email: string) => {
 
   const token = createResetPasswordToken(user.email);
 
-  await sendEmail(person._id.toString(), "reset_password", {
+  await sendEmail(person._id.toString(), {
+    name: "reset_password",
     recipient: {
       civility: person.civility,
       prenom: person.prenom,

--- a/server/src/modules/actions/auth.actions.ts
+++ b/server/src/modules/actions/auth.actions.ts
@@ -44,12 +44,10 @@ export const sendResetPasswordEmail = async (email: string) => {
 
   await sendEmail(person._id.toString(), {
     name: "reset_password",
-    recipient: {
-      civility: person.civility,
-      prenom: person.prenom,
-      nom: person.nom,
-      email: user.email,
-    },
+    to: email,
+    civility: person.civility,
+    prenom: person.prenom,
+    nom: person.nom,
     resetPasswordToken: token,
   });
 };

--- a/server/src/modules/actions/emails.actions.ts
+++ b/server/src/modules/actions/emails.actions.ts
@@ -1,59 +1,52 @@
-import { ITemplate } from "shared/mailer";
+import { ObjectId } from "mongodb";
+import { IEmailError, IEventBalEmail } from "shared/models/events/bal_emails.event";
 
 import { getDbCollection } from "@/common/utils/mongodbUtils";
 
-export function addEmail(person_id: string, token: string, template: ITemplate) {
+export async function createBalEmailEvent(person_id: string, template: IEventBalEmail["template"]) {
   const now = new Date();
-  return getDbCollection("events").findOneAndUpdate(
-    { person_id, name: "bal_emails" },
-    {
-      // @ts-expect-error
-      $push: {
-        "payload.emails": {
-          token,
-          template,
-          sendDates: [now],
-        },
-      },
-      $set: {
-        updated_at: now,
-      },
-      $setOnInsert: {
-        created_at: now,
-      },
-    },
-    { returnDocument: "after", upsert: true }
-  );
+
+  const event: IEventBalEmail = {
+    _id: new ObjectId(),
+    type: "email.bal",
+    person_id,
+    template,
+    opened_at: null,
+    delivered_at: null,
+    created_at: now,
+    updated_at: now,
+    messageId: null,
+    errors: [],
+  };
+
+  await getDbCollection("events").insertOne(event);
+  return event;
 }
 
-export function addEmailMessageId(token: string, messageId: string) {
+export function setEmailMessageId(emailEvent: IEventBalEmail, messageId: string) {
   return getDbCollection("events").findOneAndUpdate(
-    { "payload.emails.token": token, name: "bal_emails" },
+    { _id: emailEvent._id },
     {
-      // @ts-ignore
-      $addToSet: {
-        "payload.emails.$.messageIds": messageId,
-      },
-      $unset: {
-        "payload.emails.$.error": 1,
-      },
       $set: {
         updated_at: new Date(),
+        messageId,
       },
     },
     { returnDocument: "after" }
   );
 }
 
-export function addEmailError(token: string, e: Error) {
+export function addEmailError(
+  filter: Pick<IEventBalEmail, "_id"> | Pick<IEventBalEmail, "messageId">,
+  err: IEmailError
+) {
   return getDbCollection("events").findOneAndUpdate(
-    { "payload.emails.token": token, name: "bal_emails" },
+    filter,
     {
+      $push: {
+        errors: err,
+      },
       $set: {
-        "payload.emails.$.error": {
-          err_type: "fatal",
-          message: e.message,
-        },
         updated_at: new Date(),
       },
     },
@@ -62,69 +55,62 @@ export function addEmailError(token: string, e: Error) {
 }
 
 export async function markEmailAsDelivered(messageId: string) {
-  return getDbCollection("events").findOneAndUpdate(
-    { name: "bal_emails", "payload.emails.messageIds": messageId },
+  const now = new Date();
+  await getDbCollection("events").findOneAndUpdate(
+    { messageId },
     {
-      $unset: {
-        "payload.emails.$.error": 1,
-      },
       $set: {
-        updated_at: new Date(),
+        delivered_at: now,
+        updated_at: now,
       },
-    },
-    { returnDocument: "after" }
+    }
   );
 }
 
-export async function markEmailAsFailed(messageId: string, type: string) {
-  return getDbCollection("events").findOneAndUpdate(
-    { name: "bal_emails", "payload.emails.messageIds": messageId },
+export async function markEmailAsFailed(messageId: string, type: IEmailError["type"]) {
+  return addEmailError({ messageId }, { type });
+}
+
+export async function markEmailAsOpened(id: ObjectId) {
+  const now = new Date();
+  await getDbCollection("events").findOneAndUpdate(
+    { _id: id },
     {
       $set: {
-        "payload.emails.$.error": {
-          err_type: type,
-        },
-        updated_at: new Date(),
+        opened_at: now,
+        updated_at: now,
       },
-    },
-    { returnDocument: "after" }
+    }
   );
 }
 
-export async function markEmailAsOpened(token: string) {
-  return getDbCollection("events").findOneAndUpdate(
-    { "payload.emails.token": token, name: "bal_emails" },
-    {
-      $set: {
-        "payload.emails.$.openDate": new Date(),
-        updated_at: new Date(),
-      },
-    },
-    { returnDocument: "after" }
-  );
-}
+export async function unsubscribe(email: string) {
+  const now = new Date();
 
-// TODO
-export async function unsubscribeUser(id: string) {
-  return getDbCollection("events").findOneAndUpdate(
+  await getDbCollection("emailDenied").findOneAndUpdate(
     {
-      $or: [{ "payload.emails.token": id }, { "payload.emails.payload.recipient.email": id }],
-      name: "bal_emails",
+      email,
     },
     {
       $set: {
-        "payload.unsubscribe": true,
-        updated_at: new Date(),
+        reason: "unsubscribe",
+        updated_at: now,
       },
-    },
-    { returnDocument: "after" }
+      $setOnInsert: {
+        email,
+        created_at: now,
+      },
+    }
   );
 }
 
-export async function checkIfEmailExists(token: string) {
-  const count = await getDbCollection("events").countDocuments({
-    "payload.emails.token": token,
-    name: "bal_emails",
-  });
-  return count > 0;
+export async function isUnsubscribed(email: string): Promise<boolean> {
+  const denied = await getDbCollection("emailDenied").findOne(
+    {
+      email,
+    },
+    { projection: { _id: 0, email: 1 } }
+  );
+
+  return denied !== null;
 }

--- a/server/src/modules/actions/emails.actions.ts
+++ b/server/src/modules/actions/emails.actions.ts
@@ -1,23 +1,17 @@
-import { IEvent } from "shared/models/events/event.model";
+import { ITemplate } from "shared/mailer";
 
 import { getDbCollection } from "@/common/utils/mongodbUtils";
 
-export function addEmail(
-  person_id: string,
-  token: string,
-  templateName: string,
-  payload: IEvent["payload"]["emails"][number]["payload"]
-) {
+export function addEmail(person_id: string, token: string, template: ITemplate) {
   const now = new Date();
   return getDbCollection("events").findOneAndUpdate(
     { person_id, name: "bal_emails" },
     {
-      // @ts-ignore
+      // @ts-expect-error
       $push: {
         "payload.emails": {
           token,
-          templateName,
-          payload,
+          template,
           sendDates: [now],
         },
       },

--- a/server/static/emails/common/footer.ejs
+++ b/server/static/emails/common/footer.ejs
@@ -2,7 +2,7 @@
   <mj-section padding-top="0">
     <mj-column padding-top="0">
       <mj-text align="center" font-size="12px" line-height="20px">
-        <a href="<%= data.actions.preview %>" class="link-nostyle"> Voir cet email dans votre navigateur </a>
+        <a href="<%= actions.preview %>" class="link-nostyle"> Voir cet email dans votre navigateur </a>
       </mj-text>
 
       <mj-text align="left" font-size="12px" line-height="20px">
@@ -11,10 +11,10 @@
         Vous avez reçu cet email suite à une action sur le tableau de bord de l'apprentissage.
         <br />
         Pour vous désinscrire,
-        <a href="<%= data.actions.unsubscribe %>" class="link-nostyle">cliquez ici</a>
+        <a href="<%= actions.unsubscribe %>" class="link-nostyle">cliquez ici</a>
       </mj-text>
-      <% if (data.actions.markAsOpened) { %>
-      <mj-image width="1px" alt="Pixel" src="<%= data.actions.markAsOpened %>" />
+      <% if (actions.markAsOpened) { %>
+      <mj-image width="1px" alt="Pixel" src="<%= actions.markAsOpened %>" />
       <% } %>
     </mj-column>
   </mj-section>

--- a/server/static/emails/common/footer.ejs
+++ b/server/static/emails/common/footer.ejs
@@ -1,29 +1,21 @@
 <mj-wrapper padding="10px 20px">
-    <mj-section padding-top="0">
-        <mj-column padding-top="0">
+  <mj-section padding-top="0">
+    <mj-column padding-top="0">
+      <mj-text align="center" font-size="12px" line-height="20px">
+        <a href="<%= data.actions.preview %>" class="link-nostyle"> Voir cet email dans votre navigateur </a>
+      </mj-text>
 
-            <mj-text align="center" font-size="12px" line-height="20px">
-                <a
-                        href="<%= utils.getPublicUrl(`/api/emails/${data.token}/preview`) %>"
-                        class="link-nostyle">
-                    Voir cet email dans votre navigateur
-                </a>
-            </mj-text>
-
-            <mj-text align="left" font-size="12px" line-height="20px">
-                Cet email a été envoyé à <%= to %>
-                <br/>
-                Vous avez reçu cet email suite à une action sur le tableau de bord de l'apprentissage.
-                <br/>
-                Pour vous désinscrire,
-                <a href="<%= utils.getPublicUrl(`/api/emails/${data.token}/unsubscribe`) %>" class="link-nostyle">cliquez
-                    ici</a>
-            </mj-text>
-            <mj-image
-                    width="1px"
-                    alt="Pixel"
-                    src="<%= utils.getPublicUrl(`/api/emails/${data.token}/markAsOpened`) %>"/>
-        </mj-column>
-    </mj-section>
+      <mj-text align="left" font-size="12px" line-height="20px">
+        Cet email a été envoyé à <%= to %>
+        <br />
+        Vous avez reçu cet email suite à une action sur le tableau de bord de l'apprentissage.
+        <br />
+        Pour vous désinscrire,
+        <a href="<%= data.actions.unsubscribe %>" class="link-nostyle">cliquez ici</a>
+      </mj-text>
+      <% if (data.actions.markAsOpened) { %>
+      <mj-image width="1px" alt="Pixel" src="<%= data.actions.markAsOpened %>" />
+      <% } %>
+    </mj-column>
+  </mj-section>
 </mj-wrapper>
-

--- a/server/static/emails/reset_password.mjml.ejs
+++ b/server/static/emails/reset_password.mjml.ejs
@@ -7,18 +7,23 @@
       <mj-section background-color="#ffffff" padding-top="0">
         <mj-column>
           <mj-text>
-            Bonjour <strong><%= data.recipient.civility %> <%= data.recipient.prenom %> <%= data.recipient.nom %></strong>,
+            Bonjour
+            <strong
+              ><%= data.template.recipient.civility %> <%= data.template.recipient.prenom %> <%=
+              data.template.recipient.nom %></strong
+            >,
           </mj-text>
           <mj-text font-size="16px" line-height="24px" color="#000000">
             <div>
-              Une demande de réinitialisation de mot de passe a été faite pour votre compte (<%= data.recipient.email
-              %>). <br /><br />Si vous êtes à l'origine de cette demande,<br />
+              Une demande de réinitialisation de mot de passe a été faite pour votre compte (<%=
+              data.template.recipient.email %>).
+              <br /><br />Si vous êtes à l'origine de cette demande,<br />
               merci de cliquer sur le lien ci-dessous :
             </div>
           </mj-text>
 
           <mj-button
-            href="<%= utils.getPublicUrl(`/auth/modifier-mot-de-passe?passwordToken=${data.resetPasswordToken}`) %>"
+            href="<%= utils.getPublicUrl(`/auth/modifier-mot-de-passe?passwordToken=${data.template.resetPasswordToken}`) %>"
             background-color="#0e4194"
             color="white"
           >

--- a/server/static/emails/reset_password.mjml.ejs
+++ b/server/static/emails/reset_password.mjml.ejs
@@ -7,23 +7,18 @@
       <mj-section background-color="#ffffff" padding-top="0">
         <mj-column>
           <mj-text>
-            Bonjour
-            <strong
-              ><%= data.template.recipient.civility %> <%= data.template.recipient.prenom %> <%=
-              data.template.recipient.nom %></strong
-            >,
+            Bonjour <strong><%= template.civility %> <%= template.prenom %> <%= template.nom %></strong>,
           </mj-text>
           <mj-text font-size="16px" line-height="24px" color="#000000">
             <div>
-              Une demande de réinitialisation de mot de passe a été faite pour votre compte (<%=
-              data.template.recipient.email %>).
+              Une demande de réinitialisation de mot de passe a été faite pour votre compte (<%= template.to %>).
               <br /><br />Si vous êtes à l'origine de cette demande,<br />
               merci de cliquer sur le lien ci-dessous :
             </div>
           </mj-text>
 
           <mj-button
-            href="<%= utils.getPublicUrl(`/auth/modifier-mot-de-passe?passwordToken=${data.template.resetPasswordToken}`) %>"
+            href="<%= utils.getPublicUrl(`/auth/modifier-mot-de-passe?passwordToken=${template.resetPasswordToken}`) %>"
             background-color="#0e4194"
             color="white"
           >

--- a/shared/helpers/mongoSchema/__snapshots__/mongoSchemaBuilder.test.ts.snap
+++ b/shared/helpers/mongoSchema/__snapshots__/mongoSchemaBuilder.test.ts.snap
@@ -127,127 +127,169 @@ exports[`zodToMongoSchema > should convert documents schema 1`] = `
 }
 `;
 
-exports[`zodToMongoSchema > should convert events schema 1`] = `
+exports[`zodToMongoSchema > should convert emailDenied schema 1`] = `
 {
-  "additionalProperties": true,
+  "additionalProperties": false,
   "bsonType": "object",
   "properties": {
     "_id": {
       "bsonType": "objectId",
       "description": "Identifiant unique",
     },
-    "name": {
+    "created_at": {
+      "bsonType": "date",
+      "description": "Date d'ajout en base de données",
+    },
+    "email": {
       "bsonType": "string",
-      "description": "Nom de l'évènement",
+      "description": "L'email rejetée",
+    },
+    "reason": {
+      "bsonType": "string",
       "enum": [
-        "bal_emails",
+        "unsubscribe",
       ],
     },
-    "payload": {
-      "additionalProperties": true,
-      "bsonType": "object",
-      "description": "Payload de l'évènement",
-      "properties": {
-        "emails": {
-          "bsonType": "array",
-          "items": {
-            "additionalProperties": true,
-            "bsonType": "object",
-            "properties": {
-              "error": {
-                "bsonType": "array",
-                "items": {
-                  "additionalProperties": true,
-                  "bsonType": "object",
-                  "properties": {
-                    "err_type": {
-                      "bsonType": "string",
-                      "enum": [
-                        "fatal",
-                        "soft_bounce",
-                        "hard_bounce",
-                        "complaint",
-                        "invalid_email",
-                        "blocked",
-                        "error",
-                      ],
-                    },
-                    "message": {
-                      "bsonType": "string",
-                    },
-                  },
-                },
-              },
-              "messageIds": {
-                "bsonType": "array",
-                "items": {
-                  "bsonType": "string",
-                },
-              },
-              "openDate": {
-                "bsonType": "date",
-              },
-              "payload": {
-                "additionalProperties": true,
-                "bsonType": "object",
-                "properties": {
-                  "recipient": {
-                    "additionalProperties": true,
-                    "bsonType": "object",
-                    "properties": {
-                      "email": {
-                        "bsonType": "string",
-                      },
-                    },
-                    "required": [
-                      "email",
-                    ],
-                  },
-                },
-                "required": [
-                  "recipient",
-                ],
-              },
-              "sendDates": {
-                "bsonType": "array",
-                "items": {
-                  "bsonType": "date",
-                },
-              },
-              "templateName": {
-                "bsonType": "string",
-              },
-              "token": {
-                "bsonType": "string",
-              },
-            },
-            "required": [
-              "token",
-              "templateName",
-              "payload",
-              "sendDates",
-            ],
-          },
-        },
-        "unsubscribe": {
-          "bsonType": "bool",
-          "description": "unsubscribe email",
-        },
-      },
-      "required": [
-        "emails",
-      ],
-    },
-    "person_id": {
-      "bsonType": "string",
-      "description": "Identifiant de la personne",
+    "updated_at": {
+      "bsonType": "date",
+      "description": "Date de mise à jour en base de données",
     },
   },
   "required": [
     "_id",
-    "person_id",
-    "name",
-    "payload",
+    "email",
+    "reason",
+    "created_at",
+  ],
+}
+`;
+
+exports[`zodToMongoSchema > should convert events schema 1`] = `
+{
+  "anyOf": [
+    {
+      "additionalProperties": false,
+      "bsonType": "object",
+      "properties": {
+        "_id": {
+          "bsonType": "objectId",
+          "description": "Identifiant unique",
+        },
+        "created_at": {
+          "bsonType": "date",
+        },
+        "delivered_at": {
+          "anyOf": [
+            {
+              "bsonType": "date",
+            },
+            {
+              "bsonType": "null",
+            },
+          ],
+        },
+        "errors": {
+          "bsonType": "array",
+          "items": {
+            "additionalProperties": false,
+            "bsonType": "object",
+            "properties": {
+              "message": {
+                "bsonType": "string",
+              },
+              "type": {
+                "bsonType": "string",
+                "enum": [
+                  "fatal",
+                  "soft_bounce",
+                  "hard_bounce",
+                  "complaint",
+                  "invalid_email",
+                  "blocked",
+                  "error",
+                ],
+              },
+            },
+          },
+        },
+        "messageId": {
+          "bsonType": [
+            "string",
+            "null",
+          ],
+        },
+        "opened_at": {
+          "anyOf": [
+            {
+              "bsonType": "date",
+            },
+            {
+              "bsonType": "null",
+            },
+          ],
+        },
+        "person_id": {
+          "bsonType": "string",
+          "description": "Identifiant de la personne",
+        },
+        "template": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "bsonType": "object",
+              "properties": {
+                "civility": {
+                  "bsonType": "string",
+                  "enum": [
+                    "Madame",
+                    "Monsieur",
+                  ],
+                },
+                "name": {
+                  "bsonType": "string",
+                },
+                "nom": {
+                  "bsonType": "string",
+                },
+                "prenom": {
+                  "bsonType": "string",
+                },
+                "resetPasswordToken": {
+                  "bsonType": "string",
+                },
+                "to": {
+                  "bsonType": "string",
+                },
+              },
+              "required": [
+                "name",
+                "to",
+                "resetPasswordToken",
+              ],
+            },
+          ],
+        },
+        "type": {
+          "bsonType": "string",
+          "description": "Type de l'évènement",
+        },
+        "updated_at": {
+          "bsonType": "date",
+        },
+      },
+      "required": [
+        "_id",
+        "type",
+        "person_id",
+        "template",
+        "created_at",
+        "updated_at",
+        "opened_at",
+        "delivered_at",
+        "messageId",
+        "errors",
+      ],
+    },
   ],
 }
 `;

--- a/shared/mailer.ts
+++ b/shared/mailer.ts
@@ -6,14 +6,10 @@ import { z } from "zod";
 const zTemplateResetPassword = z
   .object({
     name: z.literal("reset_password"),
-    recipient: z
-      .object({
-        civility: z.enum(["Madame", "Monsieur"]).optional(),
-        prenom: z.string().optional(),
-        nom: z.string().optional(),
-        email: z.string().email(),
-      })
-      .strict(),
+    to: z.string().email(),
+    civility: z.enum(["Madame", "Monsieur"]).optional(),
+    nom: z.string().optional(),
+    prenom: z.string().optional(),
     resetPasswordToken: z.string(),
   })
   .strict();

--- a/shared/mailer.ts
+++ b/shared/mailer.ts
@@ -1,20 +1,30 @@
 // Pour chaque template, déclarer les champs qui sont utilisés dans le template
 // token: string; // obligatoire et commun à tous les emails, ajouté automatiquement dans l'emails.actions
+
+import { z } from "zod";
+
+const zTemplateResetPassword = z
+  .object({
+    name: z.literal("reset_password"),
+    recipient: z
+      .object({
+        civility: z.enum(["Madame", "Monsieur"]).optional(),
+        prenom: z.string().optional(),
+        nom: z.string().optional(),
+        email: z.string().email(),
+      })
+      .strict(),
+    resetPasswordToken: z.string(),
+  })
+  .strict();
+
+type ITemplateResetPassword = z.output<typeof zTemplateResetPassword>;
+
+export const zTemplate = z.discriminatedUnion("name", [zTemplateResetPassword]);
+
+export type ITemplate = z.output<typeof zTemplate>;
+
 export type TemplatePayloads = {
-  reset_password: {
-    recipient: {
-      civility?: "Madame" | "Monsieur" | undefined;
-      nom?: string | undefined;
-      prenom?: string | undefined;
-      email: string;
-    };
-    resetPasswordToken: string;
-  };
+  reset_password: ITemplateResetPassword;
 };
 export type TemplateName = keyof TemplatePayloads;
-
-type TemplateSubjectFunc<T extends TemplateName, Payload = TemplatePayloads[T]> = (payload: Payload) => string;
-
-export type TemplateTitleFuncs = {
-  [types in TemplateName]: TemplateSubjectFunc<types>;
-};

--- a/shared/models/common.ts
+++ b/shared/models/common.ts
@@ -11,7 +11,8 @@ export type CollectionName =
   | "sessions"
   | "documents"
   | "documentContents"
-  | "mailingLists";
+  | "mailingLists"
+  | "emailDenied";
 
 export interface IModelDescriptor {
   zod: ZodType;

--- a/shared/models/emailDenied.model.ts
+++ b/shared/models/emailDenied.model.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+import { IModelDescriptor, zObjectId } from "./common";
+
+const collectionName = "emailDenied" as const;
+
+const indexes: IModelDescriptor["indexes"] = [[{ email: 1 }, {}]];
+
+export const ZEmailDenied = z
+  .object({
+    _id: zObjectId,
+    email: z.string().describe("L'email rejetée"),
+    reason: z.enum(["unsubscribe"]),
+    updated_at: z.date().optional().describe("Date de mise à jour en base de données"),
+    created_at: z.date().describe("Date d'ajout en base de données"),
+  })
+  .strict();
+
+export type IEmailDenied = z.output<typeof ZEmailDenied>;
+
+export default {
+  zod: ZEmailDenied,
+  indexes,
+  collectionName,
+};

--- a/shared/models/events/bal_emails.event.ts
+++ b/shared/models/events/bal_emails.event.ts
@@ -1,38 +1,30 @@
 import { z } from "zod";
 
 import { zTemplate } from "../../mailer";
+import { zObjectId } from "../common";
 
-export const ZBalEmail = z
+const zEmailError = z
   .object({
-    token: z.string(),
+    type: z.enum(["fatal", "soft_bounce", "hard_bounce", "complaint", "invalid_email", "blocked", "error"]).optional(),
+    message: z.string().optional(),
+  })
+  .strict();
+
+export type IEmailError = z.output<typeof zEmailError>;
+
+export const ZEventBalEmail = z
+  .object({
+    _id: zObjectId,
+    type: z.literal("email.bal").describe("Type de l'évènement"),
+    person_id: z.string().describe("Identifiant de la personne"),
     template: zTemplate,
-    sendDates: z.array(z.date()),
-    openDate: z.date().optional(),
-    messageIds: z.array(z.string()).optional(),
-    error: z
-      .array(
-        z
-          .object({
-            err_type: z
-              .enum(["fatal", "soft_bounce", "hard_bounce", "complaint", "invalid_email", "blocked", "error"])
-              .optional(),
-            message: z.string().optional(),
-          })
-          .passthrough()
-      )
-      .optional(),
+    created_at: z.date(),
+    updated_at: z.date(),
+    opened_at: z.date().nullable(),
+    delivered_at: z.date().nullable(),
+    messageId: z.string().nullable(),
+    errors: z.array(zEmailError),
   })
-  .passthrough();
+  .strict();
 
-export const ZBalEmails = z.array(ZBalEmail);
-
-export const ZBalEmailsPayload = z
-  .object({
-    emails: ZBalEmails,
-    unsubscribe: z.boolean().optional().describe("unsubscribe email"),
-  })
-  .passthrough();
-
-export type IBalEmail = z.output<typeof ZBalEmail>;
-export type IBalEmails = z.output<typeof ZBalEmails>;
-export type IBalEmailsPayload = z.output<typeof ZBalEmailsPayload>;
+export type IEventBalEmail = z.output<typeof ZEventBalEmail>;

--- a/shared/models/events/bal_emails.event.ts
+++ b/shared/models/events/bal_emails.event.ts
@@ -1,18 +1,11 @@
 import { z } from "zod";
 
+import { zTemplate } from "../../mailer";
+
 export const ZBalEmail = z
   .object({
     token: z.string(),
-    templateName: z.string(),
-    payload: z
-      .object({
-        recipient: z
-          .object({
-            email: z.string(),
-          })
-          .passthrough(),
-      })
-      .passthrough(),
+    template: zTemplate,
     sendDates: z.array(z.date()),
     openDate: z.date().optional(),
     messageIds: z.array(z.string()).optional(),

--- a/shared/models/events/event.model.ts
+++ b/shared/models/events/event.model.ts
@@ -1,25 +1,17 @@
 import { Jsonify } from "type-fest";
 import { z } from "zod";
 
-import { IModelDescriptor, zObjectId } from "../common";
-import { ZBalEmailsPayload } from "./bal_emails.event";
+import { IModelDescriptor } from "../common";
+import { ZEventBalEmail } from "./bal_emails.event";
 
 const collectionName = "events" as const;
 
 const indexes: IModelDescriptor["indexes"] = [
   [{ person_id: 1 }, {}],
-  [{ "payload.emails.token": 1 }, {}],
-  [{ name: 1 }, {}],
+  [{ type: 1, messageId: 1 }, {}],
 ];
 
-export const ZEvent = z
-  .object({
-    _id: zObjectId,
-    person_id: z.string().describe("Identifiant de la personne"),
-    name: z.enum(["bal_emails"]).describe("Nom de l'évènement"),
-    payload: ZBalEmailsPayload.describe("Payload de l'évènement"),
-  })
-  .passthrough();
+export const ZEvent = z.discriminatedUnion("type", [ZEventBalEmail]);
 
 export type IEvent = z.output<typeof ZEvent>;
 export type IEventJson = Jsonify<z.output<typeof ZEvent>>;

--- a/shared/models/models.ts
+++ b/shared/models/models.ts
@@ -1,6 +1,7 @@
 import { IModelDescriptor } from "./common";
 import documentsModelDescriptor, { IDocument } from "./document.model";
 import documentContentsModelDescriptor, { IDocumentContent } from "./documentContent.model";
+import emailDeniedModelDescriptor, { IEmailDenied } from "./emailDenied.model";
 import eventsModelDescriptor, { IEvent } from "./events/event.model";
 import jobsModelDescriptor, { IJob } from "./job.model";
 import { IMailingList } from "./mailingList.model";
@@ -18,6 +19,7 @@ export const modelDescriptors: IModelDescriptor[] = [
   sessionsModelDescriptor,
   documentsModelDescriptor,
   documentContentsModelDescriptor,
+  emailDeniedModelDescriptor,
 ];
 
 export type IDocumentMap = {
@@ -30,4 +32,5 @@ export type IDocumentMap = {
   documents: IDocument;
   documentContents: IDocumentContent;
   mailingLists: IMailingList;
+  emailDenied: IEmailDenied;
 };

--- a/shared/routes/emails.routes.ts
+++ b/shared/routes/emails.routes.ts
@@ -1,33 +1,46 @@
 import { z } from "zod";
 
+import { zObjectId } from "../models/common";
 import { IRoutesDef } from "./common.routes";
-
-export const zEmailParams = z.object({ token: z.string() }).strict();
 
 export const zEmailRoutes = {
   get: {
-    "/emails/:token/preview": {
+    "/emails/preview": {
       method: "get",
-      path: "/emails/:token/preview",
-      params: zEmailParams,
+      path: "/emails/preview",
+      querystring: z
+        .object({
+          data: z.string(),
+        })
+        .strict(),
       response: {
         "200": z.unknown(),
       },
       securityScheme: null,
     },
-    "/emails/:token/markAsOpened": {
+    "/emails/:id/markAsOpened": {
       method: "get",
-      path: "/emails/:token/markAsOpened",
-      params: zEmailParams,
+      path: "/emails/:id/markAsOpened",
+      params: z.object({ id: zObjectId }).strict(),
       response: {
         "200": z.unknown(),
       },
-      securityScheme: null,
+      securityScheme: {
+        auth: "access-token",
+        access: null,
+        ressources: {
+          events: [{ _id: { type: "query", key: "id" } }],
+        },
+      },
     },
-    "/emails/:token/unsubscribe": {
+    "/emails/unsubscribe": {
       method: "get",
-      path: "/emails/:token/unsubscribe",
-      params: zEmailParams,
+      path: "/emails/unsubscribe",
+      querystring: z
+        .object({
+          data: z.string(),
+        })
+        .strict(),
       response: {
         "200": z.unknown(),
       },

--- a/shared/routes/emails.routes.ts
+++ b/shared/routes/emails.routes.ts
@@ -29,7 +29,7 @@ export const zEmailRoutes = {
         auth: "access-token",
         access: null,
         ressources: {
-          events: [{ _id: { type: "query", key: "id" } }],
+          events: [{ _id: { type: "params", key: "id" } }],
         },
       },
     },


### PR DESCRIPTION
**Changes:**
- Render email is now public (template data is passed via jwt token)
- Simplify event collection, one event match one email (not grouped anymore).
- Add emailDenied collection to store and control unsubscribed emails
- 