### PR TITLE
fix: correction du déploiement

### DIFF
--- a/.infra/ansible/deploy.yml
+++ b/.infra/ansible/deploy.yml
@@ -7,16 +7,10 @@
   tasks:
     - include_tasks: ./tasks/files_copy.yml
 
-    - name: Création du docker-compose.yml {{env_type}}
-      shell:
-        chdir: /opt/app
-        cmd: 'sudo docker compose $(for file in $(ls docker-compose.*.yml); do echo -n "-f $file "; done) config -o  docker-compose.yml'
-      register: docker_deploy_output
-
     - name: Récupération des images docker
       shell:
         chdir: /opt/app
-        cmd: "sudo docker compose pull"
+        cmd: "/opt/app/tools/docker-compose.sh pull"
 
     - name: Récupération du status de la stack
       shell:

--- a/.infra/files/scripts/cli.sh
+++ b/.infra/files/scripts/cli.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 #Needs to be run as sudo
 
-docker compose run --rm --no-deps server yarn cli "$@"
+/opt/app/tools/docker-compose.sh run --rm --no-deps server yarn cli "$@"

--- a/.infra/files/scripts/migrations-status.sh
+++ b/.infra/files/scripts/migrations-status.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 #Needs to be run as sudo
 
-docker compose run --rm --no-deps server yarn cli migrations:status
+/opt/app/tools/docker-compose.sh run --rm --no-deps server yarn cli migrations:status

--- a/.infra/files/scripts/migrations-up.sh
+++ b/.infra/files/scripts/migrations-up.sh
@@ -12,7 +12,7 @@ fi
 
 run_migrations(){
     echo "Application des migrations ..."
-    docker compose run --rm --no-deps server yarn cli migrations:up 2>&1 | tee "$LOG_FILEPATH"
+    /opt/app/tools/docker-compose.sh run --rm --no-deps server yarn cli migrations:up 2>&1 | tee "$LOG_FILEPATH"
 } 
 
 run_migrations

--- a/.infra/files/scripts/trigger-indexes-creation.sh
+++ b/.infra/files/scripts/trigger-indexes-creation.sh
@@ -11,7 +11,7 @@ fi
 
 trigger_indexes_creation(){
     echo "Création des index mongoDb ..."
-    docker compose run --rm --no-deps server yarn cli indexes:recreate --queued
+    /opt/app/tools/docker-compose.sh run --rm --no-deps server yarn cli indexes:recreate --queued
 } 
 
 trigger_indexes_creation


### PR DESCRIPTION
Suite au setup infra, la dernière version de docker casse le déploiement, le fichier généré par `sudo docker compose $(for file in $(ls docker-compose.*.yml); do echo -n "-f $file "; done) config -o docker-compose.yml` n'est plus valide. Il faut donc utiliser le helper `/opt/app/tools/docker-compose.sh` fourni par l'infra pour tout appel `docker compose` (sauf pour la preview qui a sont flow unique).