### PR TITLE
fix: BAL-28 Erreur de l'upload d'un fichier

### DIFF
--- a/server/src/modules/server/admin/upload.routes.ts
+++ b/server/src/modules/server/admin/upload.routes.ts
@@ -73,7 +73,7 @@ export const uploadAdminRoutes = ({ server }: { server: Server }) => {
       });
 
       if (!document) {
-        throw Boom.badImplementation("Impossible de stocker de le fichier");
+        throw Boom.badImplementation("Impossible de stocker le fichier");
       }
 
       try {
@@ -93,11 +93,14 @@ export const uploadAdminRoutes = ({ server }: { server: Server }) => {
 
         return response.status(200).send(toPublicDocument(document));
       } catch (error) {
-        await updateDocument(document._id, {
-          $set: {
-            job_status: "error",
-          },
-        });
+        await updateDocument(
+          { _id: document._id },
+          {
+            $set: {
+              job_status: "error",
+            },
+          }
+        );
 
         if (error.isBoom) {
           throw error;


### PR DESCRIPTION
L'erreur précise concernant l'upload du fichier est écrasée par une erreur de syntaxe de requête au début du traitement de l'exception.
Fix à pusher pour permettre de retenter le cas d'erreur et d'obtenir plus de contexte.
L'erreur doit être provoquée par une des quatre instructions entres les lignes 80 à 94 de upload.routes.ts