### PR TITLE
fix: suppresion de la logique brevo coté bal

### DIFF
--- a/server/src/modules/actions/tdb.actions.ts
+++ b/server/src/modules/actions/tdb.actions.ts
@@ -7,7 +7,7 @@ import {
   IBrevoContactsAPI,
 } from "../../../../shared/models/brevo.contacts.model";
 import { updateTdbRupturant } from "../../common/apis/tdb";
-import { BrevoEventStatus, IBrevoWebhookEvent, importContacts } from "../../common/services/brevo/brevo";
+import { BrevoEventStatus, IBrevoWebhookEvent } from "../../common/services/brevo/brevo";
 import {
   getCachedBouncerEmail,
   processHardbounceBouncer,
@@ -103,7 +103,6 @@ export async function processNewBrevoContact() {
     );
   }
 
-  await importContacts(brevoListe.listId, contactsValid);
   await updateTdbRupturant(tdbContacts);
 
   if (bulkOps.length === 0) {
@@ -158,27 +157,6 @@ export async function processQueuedBrevoContact() {
         },
       },
     }));
-
-    const mappedResult: Array<IBrevoContactsAPI> = chunk.emailsResult.reduce((acc, item) => {
-      const contact = chunk.emailsMap.get(item.email);
-      if (!contact || item.ping.status !== "valid") {
-        return acc;
-      }
-      return [
-        ...acc,
-        {
-          email: item.email,
-          nom: contact.nom,
-          prenom: contact.prenom,
-          urls: contact?.urls,
-          telephone: contact?.telephone,
-          nom_organisme: contact?.nom_organisme,
-          mission_locale_id: contact.mission_locale_id,
-        },
-      ];
-    }, [] as Array<IBrevoContactsAPI>);
-
-    await importContacts(brevoListe.listId, mappedResult);
 
     await updateTdbRupturant(
       chunk.emailsResult.map((item) => ({

--- a/shared/helpers/mongoSchema/__snapshots__/mongoSchemaBuilder.test.ts.snap
+++ b/shared/helpers/mongoSchema/__snapshots__/mongoSchemaBuilder.test.ts.snap
@@ -163,21 +163,6 @@ exports[`zodToMongoSchema > should convert brevo.contacts schema 1`] = `
     "email": {
       "bsonType": "string",
     },
-    "mission_locale_id": {
-      "bsonType": "string",
-    },
-    "nom": {
-      "bsonType": "string",
-    },
-    "nom_organisme": {
-      "bsonType": [
-        "string",
-        "null",
-      ],
-    },
-    "prenom": {
-      "bsonType": "string",
-    },
     "status": {
       "anyOf": [
         {
@@ -192,27 +177,8 @@ exports[`zodToMongoSchema > should convert brevo.contacts schema 1`] = `
         },
       ],
     },
-    "telephone": {
-      "bsonType": [
-        "string",
-        "null",
-      ],
-    },
     "updated_at": {
       "bsonType": "date",
-    },
-    "urls": {
-      "anyOf": [
-        {
-          "additionalProperties": {
-            "bsonType": "string",
-          },
-          "bsonType": "object",
-        },
-        {
-          "bsonType": "null",
-        },
-      ],
     },
   },
   "required": [
@@ -221,12 +187,6 @@ exports[`zodToMongoSchema > should convert brevo.contacts schema 1`] = `
     "created_at",
     "updated_at",
     "status",
-    "nom",
-    "prenom",
-    "urls",
-    "telephone",
-    "nom_organisme",
-    "mission_locale_id",
   ],
 }
 `;

--- a/shared/models/brevo.contacts.model.ts
+++ b/shared/models/brevo.contacts.model.ts
@@ -16,12 +16,6 @@ export const zBrevoContacts = z.object({
   created_at: z.date(),
   updated_at: z.date(),
   status: z.nativeEnum(BrevoContactStatusEnum).nullable(),
-  nom: z.string(),
-  prenom: z.string(),
-  urls: z.record(z.string(), z.string()).nullable(),
-  telephone: z.string().nullable(),
-  nom_organisme: z.string().nullable(),
-  mission_locale_id: z.string(),
 });
 
 export type BrevoContacts = z.output<typeof zBrevoContacts>;


### PR DESCRIPTION
Suppression de la logique brevo coté BAL.

La gestion d'import de contact dans brevo sera géré coté TDB, afin de palier les différentes possibles erreurs sur la désynchronisation entre le statut d'un jeune coté TDB et sa présence dans la liste des rupturants coté brevo

Voir : https://github.com/mission-apprentissage/flux-retour-cfas/pull/4195