### PR TITLE
fix: upload error msg csv files

### DIFF
--- a/server/src/modules/actions/documents.actions.ts
+++ b/server/src/modules/actions/documents.actions.ts
@@ -304,6 +304,8 @@ export const uploadFile = async (stream: Readable, doc: IUploadDocument, options
         })
   );
 
+  logger.info(` File ${path} uploaded to storage`);
+
   const hash_fichier = await getHash();
   const { isInfected, viruses } = await getScanResults();
 

--- a/server/src/modules/server/admin/upload.routes.ts
+++ b/server/src/modules/server/admin/upload.routes.ts
@@ -90,7 +90,10 @@ export const uploadAdminRoutes = ({ server }: { server: Server }) => {
           mimetype: data.mimetype,
         });
       } catch (error) {
-        await deleteDocumentById(document._id);
+        // CSV files are deleted through the checkCsvFile function, to get the proper error message
+        if (data.mimetype !== "text/csv") {
+          await deleteDocumentById(document._id);
+        }
 
         if (error.isBoom) {
           throw error;


### PR DESCRIPTION
checkCsvFile already delete the file after treatment, but if an error occurs, the catch was re-deleting the file, which was not present anymore and thus hiding the real issue.